### PR TITLE
Change graph_category from 'mandarina' to 'system'

### DIFF
--- a/cpu-per-core/cpu-per-core
+++ b/cpu-per-core/cpu-per-core
@@ -222,7 +222,7 @@ if ( $ARGV[0] eq "config" ) {
     print "graph_scale no\n";
     print "graph_args --upper-limit 100 --lower-limit 0 --rigid\n";
     print "graph_vlabel %\n";
-    print "graph_category mandarina\n";
+    print "graph_category system\n";
 
     print sprintf "cpu%d_system.label system\n",$cpu->{cpu};    
     print sprintf "cpu%d_system.draw AREA\n",$cpu->{cpu};


### PR DESCRIPTION
Currently the graph_category for the detailed graphs is "mandarina" - which doesn't seem to make much sense. Proposing to change this to "system" to be in-line with existing system graphs.